### PR TITLE
feat: add mock events

### DIFF
--- a/src/app/(site)/data.ts
+++ b/src/app/(site)/data.ts
@@ -1,7 +1,10 @@
 export interface Event {
   id: string;
   title: string;
-  date: string;
+  description: string;
+  startDate: string;
+  address: string;
+  images: string[];
 }
 
 export interface Place {
@@ -17,8 +20,52 @@ export interface User {
 }
 
 export const events: Event[] = [
-  { id: "1", title: "Conference", date: "2025-05-01" },
-  { id: "2", title: "Workshop", date: "2025-06-15" },
+  {
+    id: "65d37f9c0e0aef59bfa09038",
+    title: "Бал в Белграде",
+    description:
+      "Приглашаем вас на незабываемый вечер! Живая музыка, танцы и фото-зона для волшебных снимков.",
+    startDate: "2025-08-31T15:00:00.000Z",
+    address:
+      "Imperium Hall, Кеј на Ади Хуји, Београд, Централна Србија, 11060, Србија",
+    images: ["/vercel.svg"],
+  },
+  {
+    id: "1",
+    title: "Belgrade Jazz Night",
+    description:
+      "Вечер живой джазовой музыки с участием лучших музыкантов города.",
+    startDate: "2025-09-10T18:00:00.000Z",
+    address: "Jazz Club, Београд",
+    images: ["/next.svg"],
+  },
+  {
+    id: "2",
+    title: "Art Expo 2025",
+    description:
+      "Выставка современного искусства с работами молодых сербских художников.",
+    startDate: "2025-10-05T10:00:00.000Z",
+    address: "Expo Center, Нови Београд",
+    images: ["/globe.svg"],
+  },
+  {
+    id: "3",
+    title: "Danube Marathon",
+    description:
+      "Марафон вдоль Дуная для любителей бега всех уровней подготовки.",
+    startDate: "2025-04-20T07:00:00.000Z",
+    address: "Дунайская набережная, Београд",
+    images: ["/file.svg"],
+  },
+  {
+    id: "4",
+    title: "Serbian Food Fair",
+    description:
+      "Фестиваль традиционной кухни с дегустациями и мастер-классами от шеф-поваров.",
+    startDate: "2025-11-12T12:00:00.000Z",
+    address: "Трг Републике, Београд",
+    images: ["/window.svg"],
+  },
 ];
 
 export const places: Place[] = [

--- a/src/app/(site)/event/[id]/page.tsx
+++ b/src/app/(site)/event/[id]/page.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { events, findById } from "../../data";
 
 interface PageProps {
@@ -14,7 +15,14 @@ export default function EventPage({ params }: PageProps) {
   return (
     <div>
       <h1>{event.title}</h1>
-      <p>{event.date}</p>
+      <p>{new Date(event.startDate).toLocaleString()}</p>
+      <p>{event.description}</p>
+      <p>{event.address}</p>
+      <div>
+        {event.images.map((src) => (
+          <Image key={src} src={src} alt={event.title} width={200} height={200} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -8,7 +8,9 @@ export default function HomePage() {
       <ul>
         {events.map((event) => (
           <li key={event.id}>
-            <Link href={`/event/${event.id}`}>{event.title}</Link>
+            <Link href={`/event/${event.id}`}>
+              {event.title} — {new Date(event.startDate).toLocaleDateString()}
+            </Link>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- add rich mock event data
- show event dates on listing page
- display event details with description and images

## Testing
- `npm run lint` *(fails: 'UilRefresh' is defined but never used etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68acb453af9083339d2163361032e5fb