### PR TITLE
feat: add responsive layout with header and footer

### DIFF
--- a/src/app/(site)/layout.css
+++ b/src/app/(site)/layout.css
@@ -1,0 +1,51 @@
+.app-layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.site-header,
+.site-footer {
+  flex-shrink: 0;
+  padding: 1rem;
+}
+
+.site-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.site-header > .left,
+.site-header > .center,
+.site-header > .right {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.site-main {
+  flex: 1 0 auto;
+  padding: 1rem;
+}
+
+.site-footer {
+  text-align: center;
+}
+
+@media (min-width: 768px) {
+  .site-header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .site-header > .center {
+    flex: 1;
+  }
+
+  .site-header > .left,
+  .site-header > .right {
+    width: 25%;
+  }
+}

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -1,23 +1,23 @@
 import Link from "next/link";
 import { ReactNode } from "react";
+import "./layout.css";
 
 export default function SiteLayout({ children }: { children: ReactNode }) {
   return (
-    <div>
-      <nav>
-        <ul>
-          <li>
-            <Link href="/">Home</Link>
-          </li>
-          <li>
-            <Link href="/places">Places</Link>
-          </li>
-          <li>
-            <Link href="/users">Users</Link>
-          </li>
-        </ul>
-      </nav>
-      <main>{children}</main>
+    <div className="app-layout">
+      <header className="site-header">
+        <div className="left">
+          <Link href="/">Home</Link>
+        </div>
+        <div className="center">
+          <input type="text" placeholder="Filter" />
+        </div>
+        <div className="right">
+          <Link href="/login">Login</Link>
+        </div>
+      </header>
+      <main className="site-main">{children}</main>
+      <footer className="site-footer">Footer area</footer>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add site-wide layout with header placeholder, centered filter, and footer
- style layout with mobile-first responsive CSS

## Testing
- `npm run lint` *(fails: command not found; node/npm unavailable)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c67f1ff8d4833395cd1b430bc08f77