### PR TITLE
feat: add responsive header and footer layout

### DIFF
--- a/src/app/(site)/components/Footer.tsx
+++ b/src/app/(site)/components/Footer.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+import styles from './footer.module.css';
+
+export default function Footer() {
+  return (
+    <div className={styles.footer}>
+      <div className={styles.footerLeft}>
+        <div className={styles.footerMiddle}>
+          <div className={styles.footerMiddleApple}>
+            <a href="https://apps.apple.com/us/app/pllace/id6746166742">
+              <img src="/apple-store.svg" alt="Download on the App Store" />
+            </a>
+          </div>
+          <div className={styles.footerMiddleGoogle}>
+            <a href="https://play.google.com/store/apps/details?id=com.kapernikrs.expopllace">
+              <img src="/google-play.svg" alt="Get it on Google Play" />
+            </a>
+          </div>
+        </div>
+        <div className={styles.footerCopyright}>
+          <span>© 2025</span>
+          <Link className={styles.footerCopyrightLink} href="https://t.me/pllacesupport">
+            Support
+          </Link>
+        </div>
+      </div>
+      <div className={styles.footerRight}>
+        <div className={styles.footerMenu}>
+          <ul>
+            <li>
+              <a href="#">v1.1.3</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/(site)/components/Header.tsx
+++ b/src/app/(site)/components/Header.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Button, Drawer } from 'antd';
+import styles from './header.module.css';
+
+export default function Header() {
+  const [open, setOpen] = useState(false);
+  const toggleSidebar = () => setOpen(!open);
+
+  return (
+    <>
+      <Drawer
+        placement="left"
+        width={280}
+        open={open}
+        onClose={toggleSidebar}
+        className={styles.sidebarDrawer}
+      >
+        <nav className={styles.sidebar}>
+          <ul>
+            <li>
+              <Link href="/">Home</Link>
+            </li>
+            <li>
+              <Link href="/places">Places</Link>
+            </li>
+          </ul>
+        </nav>
+      </Drawer>
+      <header className={styles.siteHeader}>
+        <div className={styles.left}>
+          <Button type="link" onClick={toggleSidebar} className={styles.sidebarToggle}>
+            ☰
+          </Button>
+          <Link href="/" className="logo">
+            <img src="/logo.svg" alt="logo" />
+          </Link>
+        </div>
+        <div className={styles.center}>
+          <input type="text" placeholder="Filter" />
+        </div>
+        <div className={styles.right}>
+          <Link href="/login">Login</Link>
+        </div>
+      </header>
+    </>
+  );
+}
+

--- a/src/app/(site)/components/footer.module.css
+++ b/src/app/(site)/components/footer.module.css
@@ -1,0 +1,53 @@
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 12px 30px;
+  background: var(--color-white, #fff);
+}
+
+.footerLeft {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.footerMiddle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.footerMiddleApple img {
+  height: 50px;
+}
+
+.footerMiddleGoogle img {
+  height: 38px;
+}
+
+.footerCopyrightLink {
+  margin-left: 4px;
+  color: var(--color-primary, #1677ff);
+}
+
+.footerCopyright {}
+
+.footerRight {}
+
+.footerMenu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+@media (max-width: 576px) {
+  .footer {
+    flex-direction: column;
+    gap: 2px;
+    font-size: 12px;
+  }
+}
+

--- a/src/app/(site)/components/header.module.css
+++ b/src/app/(site)/components/header.module.css
@@ -1,0 +1,53 @@
+.siteHeader {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+  background: var(--header-bg, #fff);
+  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.05);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1rem;
+  height: 70px;
+}
+
+.left,
+.center,
+.right {
+  display: flex;
+  align-items: center;
+}
+
+.left {
+  gap: 1rem;
+}
+
+.center {
+  flex: 1;
+  justify-content: center;
+}
+
+.sidebarToggle {
+  font-size: 1.25rem;
+}
+
+.sidebarDrawer :global(.ant-drawer-body) {
+  padding: 0;
+}
+
+.sidebar {
+  padding-top: 70px;
+}
+
+.sidebar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sidebar li {
+  padding: 1rem;
+}
+

--- a/src/app/(site)/layout.css
+++ b/src/app/(site)/layout.css
@@ -4,48 +4,8 @@
   min-height: 100vh;
 }
 
-.site-header,
-.site-footer {
-  flex-shrink: 0;
-  padding: 1rem;
-}
-
-.site-header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.site-header > .left,
-.site-header > .center,
-.site-header > .right {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
 .site-main {
   flex: 1 0 auto;
   padding: 1rem;
-}
-
-.site-footer {
-  text-align: center;
-}
-
-@media (min-width: 768px) {
-  .site-header {
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-  }
-
-  .site-header > .center {
-    flex: 1;
-  }
-
-  .site-header > .left,
-  .site-header > .right {
-    width: 25%;
-  }
+  padding-top: 70px;
 }

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -1,23 +1,14 @@
-import Link from "next/link";
 import { ReactNode } from "react";
+import Header from "./components/Header";
+import Footer from "./components/Footer";
 import "./layout.css";
 
 export default function SiteLayout({ children }: { children: ReactNode }) {
   return (
     <div className="app-layout">
-      <header className="site-header">
-        <div className="left">
-          <Link href="/">Home</Link>
-        </div>
-        <div className="center">
-          <input type="text" placeholder="Filter" />
-        </div>
-        <div className="right">
-          <Link href="/login">Login</Link>
-        </div>
-      </header>
+      <Header />
       <main className="site-main">{children}</main>
-      <footer className="site-footer">Footer area</footer>
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add responsive header with sidebar drawer and search input
- introduce footer with store download links and support info
- update site layout to use new header and footer

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68c683cad45483338b30436ff104fbfb