### PR TITLE
feat: add hidden sidebar layout

### DIFF
--- a/src/app/(site)/components/Header.tsx
+++ b/src/app/(site)/components/Header.tsx
@@ -2,33 +2,18 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { Button, Drawer } from 'antd';
+import { Button } from 'antd';
+import Sidebar from './Sidebar';
 import styles from './header.module.css';
 
 export default function Header() {
   const [open, setOpen] = useState(false);
   const toggleSidebar = () => setOpen(!open);
+  const closeSidebar = () => setOpen(false);
 
   return (
     <>
-      <Drawer
-        placement="left"
-        width={280}
-        open={open}
-        onClose={toggleSidebar}
-        className={styles.sidebarDrawer}
-      >
-        <nav className={styles.sidebar}>
-          <ul>
-            <li>
-              <Link href="/">Home</Link>
-            </li>
-            <li>
-              <Link href="/places">Places</Link>
-            </li>
-          </ul>
-        </nav>
-      </Drawer>
+      <Sidebar open={open} onClose={closeSidebar} />
       <header className={styles.siteHeader}>
         <div className={styles.left}>
           <Button type="link" onClick={toggleSidebar} className={styles.sidebarToggle}>

--- a/src/app/(site)/components/Sidebar.tsx
+++ b/src/app/(site)/components/Sidebar.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import Link from 'next/link';
+import styles from './sidebar.module.css';
+
+interface SidebarProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function Sidebar({ open, onClose }: SidebarProps) {
+  return (
+    <>
+      <aside className={`${styles.sidebar} ${open ? styles.open : ''}`}>
+        <nav>
+          <ul>
+            <li>
+              <Link href="/">Home</Link>
+            </li>
+            <li>
+              <Link href="/places">Places</Link>
+            </li>
+          </ul>
+        </nav>
+      </aside>
+      {open && <div className={styles.overlay} onClick={onClose} />}
+    </>
+  );
+}

--- a/src/app/(site)/components/header.module.css
+++ b/src/app/(site)/components/header.module.css
@@ -33,21 +33,3 @@
   font-size: 1.25rem;
 }
 
-.sidebarDrawer :global(.ant-drawer-body) {
-  padding: 0;
-}
-
-.sidebar {
-  padding-top: 70px;
-}
-
-.sidebar ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.sidebar li {
-  padding: 1rem;
-}
-

--- a/src/app/(site)/components/sidebar.module.css
+++ b/src/app/(site)/components/sidebar.module.css
@@ -1,0 +1,37 @@
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 280px;
+  background: #fff;
+  box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
+  transform: translateX(-100%);
+  transition: transform 0.3s ease-in-out;
+  z-index: 1000;
+  padding-top: 70px;
+}
+
+.open {
+  transform: translateX(0);
+}
+
+.sidebar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sidebar li {
+  padding: 1rem;
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 999;
+}


### PR DESCRIPTION
## Summary
- replace Ant Design drawer with custom sidebar
- add overlay-based hidden navigation menu

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c6895d9f1083339d52154affddc4ee