### PR TITLE
style: apply theme to layout

### DIFF
--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { ThemeContext, theme } from './theme';
+
+export default function ThemeProvider({ children }: { children: ReactNode }) {
+  return (
+    <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
+  );
+}
+

--- a/src/app/(site)/components/footer.module.css
+++ b/src/app/(site)/components/footer.module.css
@@ -2,10 +2,11 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 14px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   padding: 12px 30px;
-  background: var(--color-white, #fff);
+  background: var(--color-background);
+  color: var(--color-text);
 }
 
 .footerLeft {
@@ -30,7 +31,7 @@
 
 .footerCopyrightLink {
   margin-left: 4px;
-  color: var(--color-primary, #1677ff);
+  color: var(--color-primary);
 }
 
 .footerCopyright {}
@@ -47,7 +48,7 @@
   .footer {
     flex-direction: column;
     gap: 2px;
-    font-size: 12px;
+    font-size: calc(var(--font-size-base) - 2px);
   }
 }
 

--- a/src/app/(site)/components/header.module.css
+++ b/src/app/(site)/components/header.module.css
@@ -4,7 +4,8 @@
   top: 0;
   width: 100%;
   z-index: 1000;
-  background: var(--header-bg, #fff);
+  background: var(--color-background);
+  color: var(--color-text);
   box-shadow: 0 5px 20px rgba(0, 0, 0, 0.05);
   display: flex;
   align-items: center;

--- a/src/app/(site)/components/sidebar.module.css
+++ b/src/app/(site)/components/sidebar.module.css
@@ -4,7 +4,8 @@
   left: 0;
   height: 100vh;
   width: 280px;
-  background: #fff;
+  background: var(--color-background);
+  color: var(--color-text);
   box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
   transform: translateX(-100%);
   transition: transform 0.3s ease-in-out;

--- a/src/app/(site)/layout.css
+++ b/src/app/(site)/layout.css
@@ -2,6 +2,10 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  background: var(--color-background);
+  color: var(--color-text);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-base);
 }
 
 .site-main {

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -1,14 +1,17 @@
 import { ReactNode } from "react";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
+import ThemeProvider from "@/ThemeProvider";
 import "./layout.css";
 
 export default function SiteLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="app-layout">
-      <Header />
-      <main className="site-main">{children}</main>
-      <Footer />
-    </div>
+    <ThemeProvider>
+      <div className="app-layout">
+        <Header />
+        <main className="site-main">{children}</main>
+        <Footer />
+      </div>
+    </ThemeProvider>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,12 +1,15 @@
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --color-background: #ffffff;
+  --color-text: #171717;
+  --color-primary: #1677ff;
+  --font-family-base: Arial, Helvetica, sans-serif;
+  --font-size-base: 14px;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --color-background: #0a0a0a;
+    --color-text: #ededed;
   }
 }
 
@@ -17,9 +20,10 @@ body {
 }
 
 body {
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  color: var(--color-text);
+  background: var(--color-background);
+  font-family: var(--font-family-base, Arial, Helvetica, sans-serif);
+  font-size: var(--font-size-base, 14px);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+export const theme = {
+  colors: {
+    background: '#ffffff',
+    text: '#171717',
+    primary: '#1677ff',
+  },
+  typography: {
+    fontFamily: 'Arial, Helvetica, sans-serif',
+    fontSize: '14px',
+  },
+};
+
+export const ThemeContext = createContext(theme);
+
+export const useTheme = () => useContext(ThemeContext);


### PR DESCRIPTION
## Summary
- centralize theme via context-based `useTheme` hook
- provide a `ThemeProvider` that supplies theme without DOM style mutations
- maintain global CSS variables for colors and typography

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c6912690e48333b872713fb5d6bbfe