### PR TITLE
feat: replace login with auth dropdown

### DIFF
--- a/src/app/(site)/components/header/Header.tsx
+++ b/src/app/(site)/components/header/Header.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { Button } from 'antd';
+import { Avatar, Button, Dropdown, type MenuProps } from 'antd';
+import { DownOutlined, LoginOutlined, UserAddOutlined, UserOutlined } from '@ant-design/icons';
 import Sidebar from '../sidebar/Sidebar';
 import styles from './header.module.css';
 
@@ -10,6 +11,19 @@ export default function Header() {
   const [open, setOpen] = useState(false);
   const toggleSidebar = () => setOpen(!open);
   const closeSidebar = () => setOpen(false);
+
+  const menuItems: MenuProps['items'] = [
+    {
+      key: 'signup',
+      label: <Link href="/signup">Sign Up</Link>,
+      icon: <UserAddOutlined />,
+    },
+    {
+      key: 'signin',
+      label: <Link href="/signin">Sign In</Link>,
+      icon: <LoginOutlined />,
+    },
+  ];
 
   return (
     <>
@@ -27,7 +41,12 @@ export default function Header() {
           <input type="text" placeholder="Filter" />
         </div>
         <div className={styles.right}>
-          <Link href="/login">Login</Link>
+          <Dropdown menu={{ items: menuItems }} placement="bottomRight">
+            <div className={styles.userMenu}>
+              <Avatar size="small" icon={<UserOutlined />} />
+              <DownOutlined />
+            </div>
+          </Dropdown>
         </div>
       </header>
     </>

--- a/src/app/(site)/components/header/header.module.css
+++ b/src/app/(site)/components/header/header.module.css
@@ -35,3 +35,10 @@
   font-size: 1.25rem;
 }
 
+.userMenu {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- swap header login link for avatar-triggered menu
- add styles for new user menu

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Next lint requires interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_68c6a160c5d48333a6362f019ef5780f