### PR TITLE
refactor: connect auth pages with mobx

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.scss";
+import { StoreProvider } from "@/store/StoreProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,7 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        {children}
+        <StoreProvider>{children}</StoreProvider>
       </body>
     </html>
   );

--- a/src/pages/authentication/overview/ConfirmEmail/ConfirmEmail.tsx
+++ b/src/pages/authentication/overview/ConfirmEmail/ConfirmEmail.tsx
@@ -1,20 +1,12 @@
-import React, { FC, useEffect } from "react";
+import React, { FC } from "react";
 import { Link } from "react-router-dom";
 import { Form, Input, Button, Row, Col } from "antd";
 import { AuthFormWrap } from "../style";
 import { useTranslation } from "react-i18next";
-import { useAppDispatch, useAppSelector } from "@app/store/redux/store";
-import {
-  resetPasswordAsync,
-  verificateEmailAsync,
-} from "@app/store/redux/authentication";
 import { useSearchParams } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
-import {
-  addValidationError,
-  clearFormvalidation,
-} from "@app/store/redux/formValidator";
-import * as _ from "lodash";
+import { observer } from "mobx-react-lite";
+import { useStore } from "@/store/StoreProvider";
 
 const InputGroup = Input.Group;
 
@@ -23,69 +15,57 @@ interface Props {
 }
 
 const ConfirmEmail: FC<Props> = () => {
-  const dispatch = useAppDispatch();
+  const { authStore } = useStore();
   const { t } = useTranslation();
   const [searchParams] = useSearchParams();
   const [form] = Form.useForm();
   const navigate = useNavigate();
 
-  const formValidation = useAppSelector((state) => state.formValidation);
-  const isActivated = useAppSelector((state) => state.auth.user.isActivated);
   const email = searchParams.get("email");
   const reset = searchParams.get("reset");
 
   if (!email) {
-    dispatch(
-      addValidationError({
-        message: "Please, enter email one more time!",
-        errors: [{ field: "email" }],
-      })
-    );
     navigate("/auth/forgotPassword");
   }
 
   const handleChange = () => {
-    dispatch(clearFormvalidation());
+    form.setFields([{ name: "code", errors: [] }]);
   };
 
   const handleSubmit = async (values: any) => {
     const { code1, code2, code3 } = values;
     const code = code1 + code2 + code3;
 
-    if (email && reset) {
-      const resetPassword = await dispatch(
-        resetPasswordAsync({
+    try {
+      if (email && reset) {
+        const res = await authStore.resetPassword({
           verificationCode: code,
           email: decodeURIComponent(email),
-        })
-      );
-      if (resetPassword.payload.link) {
-        const { payload } = resetPassword;
-        navigate(`/auth/resetPassword/${payload.link}`);
-      }
-      return;
-    } else {
-      const verificateEmail = await dispatch(
-        verificateEmailAsync({
+        });
+        if (res.link) {
+          navigate(`/auth/resetPassword/${res.link}`);
+        }
+      } else if (email) {
+        const res = await authStore.otp({
           verificationCode: code,
-          email: decodeURIComponent(email as string),
-        })
-      );
-      if (verificateEmail.payload.user) {
-        const { payload } = verificateEmail;
-        payload.user.isActivated
-          ? navigate("/")
-          : navigate("/auth/forgotPassword");
+          email: decodeURIComponent(email),
+        });
+        if (res.user) {
+          res.user.isActivated
+            ? navigate("/")
+            : navigate("/auth/forgotPassword");
+        }
       }
-      return;
+    } catch (e: any) {
+      if (e && typeof e === "object") {
+        const fields = Object.entries(e).map(([name, message]) => ({
+          name,
+          errors: [message as string],
+        }));
+        form.setFields(fields);
+      }
     }
   };
-
-  useEffect(() => {
-    if (formValidation.hasError) {
-      form.validateFields();
-    }
-  }, [formValidation]);
 
   return (
     <Row justify="center">
@@ -109,30 +89,12 @@ const ConfirmEmail: FC<Props> = () => {
                 label={t("auth.codeLabel")}
                 name="code"
                 rules={[
-                  () => ({
-                    validator() {
-                      if (_.find(formValidation.errors, { field: "code" })) {
-                        const { message } = _.find(formValidation.errors, {
-                          field: "code",
-                        });
-                        return Promise.reject(message);
-                      }
-                      return Promise.resolve();
-                    },
-                  }),
                   ({ getFieldValue }) => ({
                     validator() {
                       if (
-                        !_.isEmpty(getFieldValue("code1")) &&
-                        !_.isEmpty(getFieldValue("code2")) &&
-                        !_.isEmpty(getFieldValue("code3"))
-                      ) {
-                        return Promise.resolve();
-                      }
-                      if (
                         getFieldValue("code1") &&
-                        !_.isEmpty(getFieldValue("code2")) &&
-                        !_.isEmpty(getFieldValue("code3"))
+                        getFieldValue("code2") &&
+                        getFieldValue("code3")
                       ) {
                         return Promise.resolve();
                       }
@@ -226,4 +188,4 @@ const ConfirmEmail: FC<Props> = () => {
   );
 };
 
-export default ConfirmEmail;
+export default observer(ConfirmEmail);

--- a/src/pages/authentication/overview/ForgotPassword/ForgotPassword.tsx
+++ b/src/pages/authentication/overview/ForgotPassword/ForgotPassword.tsx
@@ -1,13 +1,11 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { FC } from "react";
 import { Link } from "react-router-dom";
 import { Form, Input, Button, Row, Col } from "antd";
 import { AuthFormWrap } from "../style";
 import { useTranslation } from "react-i18next";
 import { createSearchParams, useNavigate } from "react-router-dom";
-import * as _ from "lodash";
-import { useAppDispatch, useAppSelector } from "@app/store/redux/store";
-import { clearFormvalidation } from "@app/store/redux/formValidator";
-import { activateEmailAsync } from "@app/store/redux/authentication";
+import { observer } from "mobx-react-lite";
+import { useStore } from "@/store/StoreProvider";
 
 interface Props {
   path: string;
@@ -15,35 +13,34 @@ interface Props {
 
 const ForgotPassword: FC<Props> = ({ path = "" }) => {
   const { t } = useTranslation();
-  const dispatch = useAppDispatch();
+  const { authStore } = useStore();
   const [form] = Form.useForm();
   const navigate = useNavigate();
-  const formValidation = useAppSelector((state) => state.formValidation);
 
   const handleChange = () => {
-    dispatch(clearFormvalidation());
+    form.setFields([{ name: "email", errors: [] }]);
   };
 
   const handleSubmit = async (values: any) => {
     const { email } = values;
-    const isEmailExist = await dispatch(activateEmailAsync(email));
-
-    if (isEmailExist.payload.user) {
-      navigate({
-        pathname: "/auth/confirmEmail",
-        search: createSearchParams({
-          email,
-          reset: "true",
-        }).toString(),
-      });
+    try {
+      const res = await authStore.activateEmail(email);
+      if (res.user) {
+        navigate({
+          pathname: "/auth/confirmEmail",
+          search: createSearchParams({ email, reset: "true" }).toString(),
+        });
+      }
+    } catch (e: any) {
+      if (e && typeof e === "object") {
+        const fields = Object.entries(e).map(([name, message]) => ({
+          name,
+          errors: [message as string],
+        }));
+        form.setFields(fields);
+      }
     }
   };
-
-  useEffect(() => {
-    if (formValidation.hasError) {
-      form.validateFields();
-    }
-  }, [formValidation]);
 
   return (
     <Row justify="center">
@@ -72,17 +69,6 @@ const ForgotPassword: FC<Props> = ({ path = "" }) => {
                     required: true,
                     message: t("auth.validation.email") as string,
                   },
-                  () => ({
-                    validator() {
-                      if (_.find(formValidation.errors, { field: "email" })) {
-                        const { message } = _.find(formValidation.errors, {
-                          field: "email",
-                        });
-                        return Promise.reject(message);
-                      }
-                      return Promise.resolve();
-                    },
-                  }),
                 ]}
               >
                 <Input placeholder={t("auth.placeholderEmail") as string} />
@@ -111,4 +97,4 @@ const ForgotPassword: FC<Props> = ({ path = "" }) => {
   );
 };
 
-export default ForgotPassword;
+export default observer(ForgotPassword);

--- a/src/pages/authentication/overview/ResetPassword/ResetPassword.tsx
+++ b/src/pages/authentication/overview/ResetPassword/ResetPassword.tsx
@@ -1,13 +1,11 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { FC } from "react";
 import { Link, useParams } from "react-router-dom";
 import { Form, Input, Button, Row, Col } from "antd";
 import { AuthFormWrap } from "../style";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
-import * as _ from "lodash";
-import { useAppDispatch, useAppSelector } from "@app/store/redux/store";
-import { clearFormvalidation } from "@app/store/redux/formValidator";
-import { newPasswordAsync } from "@app/store/redux/authentication";
+import { observer } from "mobx-react-lite";
+import { useStore } from "@/store/StoreProvider";
 
 interface Props {
   path: string;
@@ -15,10 +13,9 @@ interface Props {
 
 const ResetPassword: FC<Props> = ({ path = "" }) => {
   const { t } = useTranslation();
-  const dispatch = useAppDispatch();
+  const { authStore } = useStore();
   const [form] = Form.useForm();
   const navigate = useNavigate();
-  const formValidation = useAppSelector((state) => state.formValidation);
   const { link } = useParams();
 
   if (!link) {
@@ -26,24 +23,28 @@ const ResetPassword: FC<Props> = ({ path = "" }) => {
   }
 
   const handleChange = () => {
-    dispatch(clearFormvalidation());
+    form.setFields([{ name: "password", errors: [] }]);
   };
 
   const handleSubmit = async (values: any) => {
-    const isEmailExist = await dispatch(
-      newPasswordAsync({ password: values.password, activatedLink: link })
-    );
-
-    if (isEmailExist.payload.user) {
-      navigate("/auth");
+    try {
+      const res = await authStore.newPassword({
+        password: values.password,
+        activatedLink: link as string,
+      });
+      if (res.user) {
+        navigate("/auth");
+      }
+    } catch (e: any) {
+      if (e && typeof e === "object") {
+        const fields = Object.entries(e).map(([name, message]) => ({
+          name,
+          errors: [message as string],
+        }));
+        form.setFields(fields);
+      }
     }
   };
-
-  useEffect(() => {
-    if (formValidation.hasError) {
-      form.validateFields();
-    }
-  }, [formValidation]);
 
   return (
     <Row justify="center">
@@ -74,19 +75,6 @@ const ResetPassword: FC<Props> = ({ path = "" }) => {
                     min: 6,
                     message: t("auth.validation.minPassword6") as string,
                   },
-                  () => ({
-                    validator() {
-                      if (
-                        _.find(formValidation.errors, { field: "password" })
-                      ) {
-                        const { message } = _.find(formValidation.errors, {
-                          field: "password",
-                        });
-                        return Promise.reject(message);
-                      }
-                      return Promise.resolve();
-                    },
-                  }),
                 ]}
               >
                 <Input.Password placeholder={t("auth.password") as string} />
@@ -139,4 +127,4 @@ const ResetPassword: FC<Props> = ({ path = "" }) => {
   );
 };
 
-export default ResetPassword;
+export default observer(ResetPassword);

--- a/src/pages/authentication/overview/SignIn/SignIn.tsx
+++ b/src/pages/authentication/overview/SignIn/SignIn.tsx
@@ -1,5 +1,5 @@
 import { Button, Col, Form, Input, Row } from "antd";
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, useState } from "react";
 import { GoogleOAuthProvider, GoogleLogin } from "@react-oauth/google";
 
 import {
@@ -10,15 +10,10 @@ import {
 } from "react-router-dom";
 import { AuthFormWrap } from "../style";
 import { Checkbox } from "@app/components/UIElements/checkbox/checkbox";
-import { useAppDispatch, useAppSelector } from "@app/store/redux/store";
 import { useTranslation } from "react-i18next";
-import {
-  LoginParams,
-  loginAsync,
-  loginGoogleAsync,
-} from "@app/store/redux/authentication";
-import * as _ from "lodash";
-import { clearFormvalidation } from "@app/store/redux/formValidator";
+import { observer } from "mobx-react-lite";
+import { useStore } from "@/store/StoreProvider";
+import { LoginParams } from "@/store/mobx/auth";
 
 interface Props {
   path: string;
@@ -26,12 +21,9 @@ interface Props {
 
 const SignIn: FC<Props> = () => {
   const navigate = useNavigate();
-  const dispatch = useAppDispatch();
+  const { authStore } = useStore();
   const [form] = Form.useForm();
   const { t } = useTranslation();
-
-  const isLoading = useAppSelector((state) => state.auth.loading);
-  const formValidation = useAppSelector((state) => state.formValidation);
 
   const [state, setState] = useState({
     checked: null,
@@ -39,29 +31,32 @@ const SignIn: FC<Props> = () => {
 
   const handleGoogleSuccess = async (response: any) => {
     const credential = response?.credential;
-
-    const login = await dispatch(loginGoogleAsync(credential));
-    if (!login.type.includes("rejected")) {
+    try {
+      await authStore.loginByGoogle(credential);
       navigate("/");
+    } catch (e) {
+      console.log(e);
     }
-    // Отправьте токен на ваш сервер для дополнительной проверки и аутентификации пользователя
-    // например, с помощью fetch или axios
   };
 
   const handleSubmit = async ({ email, password }: LoginParams) => {
-    const login = await dispatch(loginAsync({ email, password }));
-
-    if (!login.type.includes("rejected")) {
-      const { payload }: any = login;
-      if (!payload.user.isActivated) {
+    try {
+      const data = await authStore.login({ email, password });
+      if (!data.user.isActivated) {
         navigate({
           pathname: "/auth/confirmEmail",
-          search: createSearchParams({
-            email,
-          }).toString(),
+          search: createSearchParams({ email }).toString(),
         });
       } else {
         navigate("/");
+      }
+    } catch (e: any) {
+      if (e && typeof e === "object") {
+        const fields = Object.entries(e).map(([name, message]) => ({
+          name,
+          errors: [message as string],
+        }));
+        form.setFields(fields);
       }
     }
   };
@@ -71,16 +66,11 @@ const SignIn: FC<Props> = () => {
   };
 
   const handleForm = () => {
-    if (formValidation.message) {
-      dispatch(clearFormvalidation());
-    }
+    form.setFields([
+      { name: "email", errors: [] },
+      { name: "password", errors: [] },
+    ]);
   };
-
-  useEffect(() => {
-    if (formValidation.hasError) {
-      form.validateFields();
-    }
-  }, [formValidation]);
 
   return (
     <Row justify="center">
@@ -106,17 +96,6 @@ const SignIn: FC<Props> = () => {
                     message: t("auth.validation.emailOrUsername") as string,
                     required: true,
                   },
-                  () => ({
-                    validator() {
-                      if (_.find(formValidation.errors, { field: "email" })) {
-                        const { message } = _.find(formValidation.errors, {
-                          field: "email",
-                        });
-                        return Promise.reject(message);
-                      }
-                      return Promise.resolve();
-                    },
-                  }),
                 ]}
                 initialValue="testuser1@gmail.com"
                 label={t("auth.usernameOrEmail")}
@@ -136,19 +115,6 @@ const SignIn: FC<Props> = () => {
                     min: 6,
                     message: t("auth.validation.minPassword6") as string,
                   },
-                  () => ({
-                    validator() {
-                      if (
-                        _.find(formValidation.errors, { field: "password" })
-                      ) {
-                        const { message } = _.find(formValidation.errors, {
-                          field: "password",
-                        });
-                        return Promise.reject(message);
-                      }
-                      return Promise.resolve();
-                    },
-                  }),
                 ]}
               >
                 <Input.Password placeholder={t("auth.password") as string} />
@@ -168,7 +134,7 @@ const SignIn: FC<Props> = () => {
                   type="primary"
                   size="large"
                 >
-                  {isLoading ? t("auth.loading") : t("auth.signIn")}
+                  {authStore.loading ? t("auth.loading") : t("auth.signIn")}
                 </Button>
               </Form.Item>
               <p className="pllace-form-divider">
@@ -202,4 +168,4 @@ const SignIn: FC<Props> = () => {
   );
 };
 
-export default SignIn;
+export default observer(SignIn);

--- a/src/pages/authentication/overview/Signup/Signup.tsx
+++ b/src/pages/authentication/overview/Signup/Signup.tsx
@@ -1,50 +1,50 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { FC } from "react";
 import { Link, createSearchParams, useNavigate } from "react-router-dom";
 import { Row, Col, Form, Input, Button } from "antd";
 
 import { AuthFormWrap } from "../style";
 import { Checkbox } from "@app/components/UIElements/checkbox/checkbox";
-import { useAppDispatch, useAppSelector } from "@app/store/redux/store";
 import { useTranslation } from "react-i18next";
-import {
-  RegistrationParams,
-  registrationAsync,
-} from "@app/store/redux/authentication";
-import { clearFormvalidation } from "@app/store/redux/formValidator";
-import * as _ from "lodash";
+import { observer } from "mobx-react-lite";
+import { useStore } from "@/store/StoreProvider";
+import { RegistrationParams } from "@/store/mobx/auth";
 
 interface Props {
   path: string;
 }
 
 const SignUp: FC<Props> = () => {
-  const dispatch = useAppDispatch();
+  const { authStore } = useStore();
   const { t } = useTranslation();
   const [form] = Form.useForm();
   const navigate = useNavigate();
-  const formValidation = useAppSelector((state) => state.formValidation);
 
   const handleSubmit = async (values: RegistrationParams) => {
-    const registration = await dispatch(registrationAsync(values));
-    if (!registration.type.includes("rejected")) {
+    try {
+      await authStore.registration(values);
       navigate({
         pathname: "/auth/confirmEmail",
-        search: createSearchParams({
-          email: values.email,
-        }).toString(),
+        search: createSearchParams({ email: values.email }).toString(),
       });
+    } catch (e: any) {
+      if (e && typeof e === "object") {
+        const fields = Object.entries(e).map(([name, message]) => ({
+          name,
+          errors: [message as string],
+        }));
+        form.setFields(fields);
+      }
     }
   };
 
   const handleForm = () => {
-    dispatch(clearFormvalidation());
+    form.setFields([
+      { name: "name", errors: [] },
+      { name: "lastname", errors: [] },
+      { name: "email", errors: [] },
+      { name: "password", errors: [] },
+    ]);
   };
-
-  useEffect(() => {
-    if (formValidation.hasError) {
-      form.validateFields();
-    }
-  }, [formValidation]);
 
   return (
     <Row justify="center">
@@ -71,17 +71,6 @@ const SignUp: FC<Props> = () => {
                     required: true,
                     message: t("auth.validation.name") as string,
                   },
-                  () => ({
-                    validator() {
-                      if (_.find(formValidation.errors, { field: "name" })) {
-                        const { message } = _.find(formValidation.errors, {
-                          field: "name",
-                        });
-                        return Promise.reject(message);
-                      }
-                      return Promise.resolve();
-                    },
-                  }),
                 ]}
               >
                 <Input placeholder={t("auth.placeholderName") as string} />
@@ -94,19 +83,6 @@ const SignUp: FC<Props> = () => {
                     required: true,
                     message: t("auth.validation.lastname") as string,
                   },
-                  () => ({
-                    validator() {
-                      if (
-                        _.find(formValidation.errors, { field: "lastname" })
-                      ) {
-                        const { message } = _.find(formValidation.errors, {
-                          field: "lastname",
-                        });
-                        return Promise.reject(message);
-                      }
-                      return Promise.resolve();
-                    },
-                  }),
                 ]}
               >
                 <Input placeholder={t("auth.placeholderName") as string} />
@@ -120,17 +96,6 @@ const SignUp: FC<Props> = () => {
                     required: true,
                     message: t("auth.validation.email") as string,
                   },
-                  () => ({
-                    validator() {
-                      if (_.find(formValidation.errors, { field: "email" })) {
-                        const { message } = _.find(formValidation.errors, {
-                          field: "email",
-                        });
-                        return Promise.reject(message);
-                      }
-                      return Promise.resolve();
-                    },
-                  }),
                 ]}
               >
                 <Input placeholder={t("auth.placeholderEmail") as string} />
@@ -147,19 +112,6 @@ const SignUp: FC<Props> = () => {
                     min: 6,
                     message: t("auth.validation.minPassword6") as string,
                   },
-                  () => ({
-                    validator() {
-                      if (
-                        _.find(formValidation.errors, { field: "password" })
-                      ) {
-                        const { message } = _.find(formValidation.errors, {
-                          field: "password",
-                        });
-                        return Promise.reject(message);
-                      }
-                      return Promise.resolve();
-                    },
-                  }),
                 ]}
               >
                 <Input.Password placeholder={t("auth.password") as string} />
@@ -232,4 +184,4 @@ const SignUp: FC<Props> = () => {
   );
 };
 
-export default SignUp;
+export default observer(SignUp);


### PR DESCRIPTION
## Summary
- wrap app with StoreProvider to expose MobX root store
- migrate sign in and registration pages to use authStore
- replace remaining auth flow pages with MobX authStore logic

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68c70dd562f08333b55fbfb03c91d7fe